### PR TITLE
feat: add CI workflow for building Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
   test-lint:
     name: Run Tests & Linting
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -27,20 +26,46 @@ jobs:
         run: |
           python -m venv venv
           venv/bin/pip install -r requirements.txt
-          # Install xvfb and python3-tk only if running with act locally
+          # Install xvfb and python3-tk if running locally with act
           if [ "$ACT" = "true" ]; then
             sudo apt-get update && sudo apt-get install -y xvfb python3-tk
           fi
 
       - name: Check Formatting (Black)
-        run: |
-          venv/bin/black --check .
+        run: venv/bin/black --check .
 
       - name: Run Linting (Flake8)
-        run: |
-          venv/bin/flake8 .
+        run: venv/bin/flake8 .
 
       - name: Run Tests with Virtual Display
-        run: |
-          xvfb-run --auto-servernum venv/bin/pytest -v
+        run: xvfb-run --auto-servernum venv/bin/pytest -v
 
+  build-windows:
+    name: Build Windows Executable
+    runs-on: windows-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Create Virtual Environment and Install Dependencies
+        run: |
+          python -m venv venv
+          venv\Scripts\pip install -r requirements.txt
+          venv\Scripts\pip install pyinstaller
+
+      - name: Build Executable
+        run: |
+          venv\Scripts\pyinstaller --onefile --windowed --name wftracker run.py
+
+      - name: Archive Windows Executable
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: wftracker
+          path: dist\wftracker.exe


### PR DESCRIPTION
This pull request introduces a new job to the CI workflow for building a Windows executable. The most important change is the addition of a `build-windows` job in the `.github/workflows/ci.yml` file.

Changes to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR47-R74): Added a new job `build-windows` to build a Windows executable. This job includes steps for checking out the repository, setting up Python, creating a virtual environment, installing dependencies, building the executable using `pyinstaller`, and archiving the resulting executable.